### PR TITLE
Fix default tmp_dir

### DIFF
--- a/lib/twilio_recordings.rb
+++ b/lib/twilio_recordings.rb
@@ -3,6 +3,7 @@ require 'typhoeus/adapters/faraday'
 
 class TwilioRecordings
   attr_writer :connection
+  attr_reader :tmp_dir 	# For testing
 
   ##
   # Instantiate a new TwilioRecordings object.
@@ -14,11 +15,11 @@ class TwilioRecordings
   # Arguments:
   #   account_sid: The Twilio account SID, e.g. "AC12345678901234567890123456789012"
   #   recording_sids: An array of recording SIDs, e.g. ["RE12345678901234567890123456789012"]
-  #   tmp_dir: The directory that the recordings will be temporarily downloaded to. (optional, default is '/tmp')
+  #   tmp_dir: The directory that the recordings will be temporarily downloaded to. (optional, default is Dir.tmpdir() )
   def initialize(account_sid, recording_sids, options={})
     @account_sid = account_sid
     @recording_sids = recording_sids.map{ |sid| self.class.sanitize(sid) }
-    @tmp_dir = options[:tmp_dir] || File.join('','tmp')
+    @tmp_dir = options[:tmp_dir] || Dir.tmpdir
 
     @tmp_files = {}
   end

--- a/spec/twilio_recordings_spec.rb
+++ b/spec/twilio_recordings_spec.rb
@@ -18,6 +18,7 @@ describe TwilioRecordings do
     @tmp_dir = File.join('.','spec','tmp')
 
     FileUtils.mkdir_p(@tmp_dir) # Create tmp dir if it doesn't exist
+    FileUtils.chmod '+t', @tmp_dir # Need sticky bit for Dir.tmpdir
 
     @stubbed_filenames = @recording_sids.map { |sid| sid + ".mp3" }
     @expected_urls     = @stubbed_filenames.map { |filename| @twilio_api_url + filename }
@@ -36,6 +37,28 @@ describe TwilioRecordings do
   describe ".sanitize" do
     it "must remove '..'" do
       TwilioRecordings.sanitize('../etc/passwd').must_equal 'etcpasswd'
+    end
+  end
+
+  describe "#initialize" do
+    it "must use default /tmp directory" do
+      original_tmpdir = ENV['TMPDIR']
+      ENV['TMPDIR'] = nil
+
+      twilio_recordings = TwilioRecordings.new(@account_sid, [])
+      twilio_recordings.tmp_dir.must_equal '/tmp'
+
+      ENV['TMPDIR'] = original_tmpdir
+    end
+
+    it "must use selected TMPDIR directory" do
+      original_tmpdir = ENV['TMPDIR']
+      ENV['TMPDIR'] = @tmp_dir
+
+      twilio_recordings = TwilioRecordings.new(@account_sid, [])
+      twilio_recordings.tmp_dir.must_equal File.expand_path(@tmp_dir)
+
+      ENV['TMPDIR'] = original_tmpdir
     end
   end
 


### PR DESCRIPTION
This PR fix the behavior for the default tmp dir.

If `tmp_dir` is not provided, it will use the value provided by `Dir.tmpdir`, which take in account the environment variable configuration. So the default value is not hardcoded to `/tmp`.

See https://www.rubydoc.info/stdlib/tmpdir/Dir#tmpdir-class_method for more details on the implementation.